### PR TITLE
Witness gen only flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=9fd0425f6781129cb09e6df94c7a584bda1c97ff#9fd0425f6781129cb09e6df94c7a584bda1c97ff"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=01bbf1a05874bb4a92704d4cb36adb271943a15e#01bbf1a05874bb4a92704d4cb36adb271943a15e"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "eth_trie_utils"
 version = "0.6.0"
-source = "git+https://github.com/mir-protocol/eth_trie_utils.git?rev=e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5#e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5"
+source = "git+https://github.com/0xPolygonZero/eth_trie_utils.git?rev=e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5#e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5"
 dependencies = [
  "bytes",
  "enum-as-inner",
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=1d60431992ab3cc90addfa12b43f851e35ad97cb#1d60431992ab3cc90addfa12b43f851e35ad97cb"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=49976ea2a98dcb6052bd6cf3a65f730e55727330#49976ea2a98dcb6052bd6cf3a65f730e55727330"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8af189b92721af7d568a04441d840c12156ae8b7#8af189b92721af7d568a04441d840c12156ae8b7"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=b9328815e666981d6485b0d8dc04160e93797993#b9328815e666981d6485b0d8dc04160e93797993"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=b9328815e666981d6485b0d8dc04160e93797993#b9328815e666981d6485b0d8dc04160e93797993"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=b9328815e666981d6485b0d8dc04160e93797993#b9328815e666981d6485b0d8dc04160e93797993"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=b9328815e666981d6485b0d8dc04160e93797993#b9328815e666981d6485b0d8dc04160e93797993"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89#f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=b9328815e666981d6485b0d8dc04160e93797993#b9328815e666981d6485b0d8dc04160e93797993"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3#51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3#51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3#51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3#51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3#51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=0de6f949622a6410835bb776c40cc3cad04316a9#0de6f949622a6410835bb776c40cc3cad04316a9"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=e41435e92789854fcff73040502e0768a4dd5ec0#e41435e92789854fcff73040502e0768a4dd5ec0"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=44af80f244e7b416d05dd81681d9d21bf78c5779#44af80f244e7b416d05dd81681d9d21bf78c5779"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=f71f227d3ca8ac6da62ff3748a2279dc4fd23c77#f71f227d3ca8ac6da62ff3748a2279dc4fd23c77"
 
 [[package]]
 name = "portable-atomic"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
-eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
+eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "b9328815e666981d6485b0d8dc04160e93797993" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -46,7 +46,7 @@ impl ParsedTestManifest {
                     receipts_root: t_var.final_roots.receipts_trie_root_hash,
                 };
                 let gen_inputs = GenerationInputs {
-                    signed_txns: vec![t_var.txn_bytes],
+                    signed_txn: Some(t_var.txn_bytes),
                     tries: t_var.plonky2_metadata.tries.clone(),
                     trie_roots_after,
                     genesis_state_trie_root: t_var.plonky2_metadata.genesis_state_root,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -58,6 +58,7 @@ impl ParsedTestManifest {
                     block_bloom_before: [U256::zero(); 8],
                     gas_used_after: t_var.plonky2_metadata.block_metadata.block_gas_used,
                     block_bloom_after: t_var.plonky2_metadata.block_metadata.block_bloom,
+                    withdrawals: t_var.plonky2_metadata.withdrawals,
                     block_hashes: BlockHashes::default(),
                 };
 
@@ -117,6 +118,7 @@ pub struct TestMetadata {
     pub contract_code: HashMap<H256, Vec<u8>>,
     pub block_metadata: BlockMetadata,
     pub addresses: Vec<Address>,
+    pub withdrawals: Vec<(Address, U256)>,
 }
 
 #[derive(Clone, Debug)]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -62,6 +62,7 @@ impl ParsedTestManifest {
                 };
 
                 TestVariantRunInfo {
+                    variant_name: t_var.test_name,
                     gen_inputs,
                     final_roots: t_var.final_roots,
                     variant_idx,
@@ -81,6 +82,8 @@ impl ParsedTestManifest {
 /// Note that for our runner we break any txn "variants" (see `indexes` under https://ethereum-tests.readthedocs.io/en/latest/test_types/gstate_tests.html#post-section) into separate sub-tests when running. This is because we don't want a single sub-test variant to cause the entire test to fail (we just want the variant to fail).
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Plonky2ParsedTest {
+    pub test_name: String,
+
     pub txn_bytes: Vec<u8>,
     pub final_roots: ExpectedFinalRoots,
 
@@ -90,6 +93,8 @@ pub struct Plonky2ParsedTest {
 
 #[derive(Debug)]
 pub struct TestVariantRunInfo {
+    pub variant_name: String,
+
     pub gen_inputs: GenerationInputs,
     pub final_roots: ExpectedFinalRoots,
     pub variant_idx: usize,

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "b9328815e666981d6485b0d8dc04160e93797993" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
+eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -369,6 +369,7 @@ pub(crate) struct PreAccount {
 
 #[derive(Debug)]
 pub(crate) struct TestBody {
+    pub(crate) name: String,
     pub(crate) block: Block,
     // The genesis block has an empty transactions list, which needs a
     // different handling than the logic present in `Block` decoding.
@@ -377,12 +378,13 @@ pub(crate) struct TestBody {
 }
 
 impl TestBody {
-    fn from_parsed_json(value: &ValueJson) -> Self {
+    fn from_parsed_json(value: &ValueJson, variant_name: String) -> Self {
         let block: Block = rlp::decode(&value.blocks[0].rlp.0).unwrap();
         let genesis_block: GenesisBlock =
             rlp::decode(&value.genesis_rlp.as_ref().unwrap().0).unwrap();
 
         Self {
+            name: variant_name,
             block,
             genesis_block,
             pre: value.pre.clone(),
@@ -444,7 +446,7 @@ impl<'de> Deserialize<'de> for TestFile {
                 while let Some((key, value)) = access.next_entry::<String, ValueJson>()? {
                     if key.contains("Shanghai") {
                         if value.blocks[0].transaction_sequence.is_none() {
-                            let value = TestBody::from_parsed_json(&value);
+                            let value = TestBody::from_parsed_json(&value, key.clone());
                             map.0.insert(key, value);
                         } else {
                             // Some tests deal with malformed transactions that wouldn't be passed

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -302,8 +302,8 @@ impl Decodable for Transaction {
 pub(crate) struct Withdrawal {
     pub(crate) _index: U256,
     pub(crate) _validator_index: U256,
-    pub(crate) _address: H160,
-    pub(crate) _amount: U256,
+    pub(crate) address: H160,
+    pub(crate) amount: U256,
 }
 
 #[derive(Debug, RlpDecodable)]
@@ -311,7 +311,7 @@ pub(crate) struct Block {
     pub(crate) block_header: BlockHeader,
     pub(crate) transactions: Transactions,
     pub(crate) _uncle_headers: Vec<BlockHeader>,
-    pub(crate) _withdrawals: Vec<Withdrawal>,
+    pub(crate) withdrawals: Vec<Withdrawal>,
 }
 
 #[derive(Debug, RlpDecodable)]

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -440,7 +440,15 @@ impl<'de> Deserialize<'de> for TestFile {
                                 // Ensure that the encoding we will provide the zkEVM prover is in
                                 // the block RLP.
                                 if rlp.windows(encoded_txn.len()).any(|c| c == encoded_txn) {
-                                    map.0.insert(key, test_body);
+                                    // Finally, ensure that the gas used fits in 32 bits, otherwise
+                                    // the prover will abort.
+                                    if TryInto::<u32>::try_into(
+                                        test_body.block.block_header.gas_used,
+                                    )
+                                    .is_ok()
+                                    {
+                                        map.0.insert(key, test_body);
+                                    }
                                 }
                             }
                         } else {

--- a/eth_test_parser/src/fs_scaffolding.rs
+++ b/eth_test_parser/src/fs_scaffolding.rs
@@ -130,5 +130,10 @@ fn get_deserialized_test_body(entry: &DirEntry) -> Result<Vec<TestBody>> {
     let buf = BufReader::new(File::open(entry.path())?);
     let test_file: TestFile = serde_json::from_reader(buf)?;
 
-    anyhow::Ok(test_file.0.into_values().collect())
+    let tests: Vec<TestBody> = test_file.0.into_values().collect();
+    if tests.is_empty() {
+        Err(anyhow!("No valid tests found"))
+    } else {
+        anyhow::Ok(tests)
+    }
 }

--- a/eth_test_parser/src/trie_builder.rs
+++ b/eth_test_parser/src/trie_builder.rs
@@ -86,6 +86,11 @@ impl TestBody {
             genesis_state_root: self.genesis_block.block_header.state_root,
             block_metadata: self.block.block_metadata(),
             addresses,
+            withdrawals: block
+                .withdrawals
+                .iter()
+                .map(|w| (w.address, w.amount))
+                .collect(),
         };
 
         Plonky2ParsedTest {

--- a/eth_test_parser/src/trie_builder.rs
+++ b/eth_test_parser/src/trie_builder.rs
@@ -89,6 +89,7 @@ impl TestBody {
         };
 
         Plonky2ParsedTest {
+            test_name: self.name.clone(),
             txn_bytes: self.get_txn_bytes(),
             final_roots: ExpectedFinalRoots {
                 state_root_hash: header.state_root,

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "1d60431992ab3cc90addfa12b43f851e35ad97cb" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "49976ea2a98dcb6052bd6cf3a65f730e55727330" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8af189b92721af7d568a04441d840c12156ae8b7" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "e41435e92789854fcff73040502e0768a4dd5ec0" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "01bbf1a05874bb4a92704d4cb36adb271943a15e" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f879d9256e1b5c3e059fd4b5df0cb33a9ba60f89" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "b9328815e666981d6485b0d8dc04160e93797993" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "b9328815e666981d6485b0d8dc04160e93797993" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "9fd0425f6781129cb09e6df94c7a584bda1c97ff" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "44af80f244e7b416d05dd81681d9d21bf78c5779" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f71f227d3ca8ac6da62ff3748a2279dc4fd23c77" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "51eb7c0b5221e6fce5a39beac6a9ba274b2d71b3" }
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "0de6f949622a6410835bb776c40cc3cad04316a9" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -42,6 +42,11 @@ pub(crate) struct ProgArgs {
     #[arg(short = 'p', long)]
     pub(crate) skip_passed: bool,
 
+    /// Only generate the witness and not the entire proof (significantly
+    /// faster, but may give false negatives).
+    #[arg(short = 'w', long)]
+    pub(crate) witness_only: bool,
+
     /// Mark a test as timed out if it takes longer than this amount of time.
     #[arg(short = 't', long)]
     pub(crate) test_timeout: Option<humantime::Duration>,

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -56,6 +56,7 @@ async fn run() -> anyhow::Result<bool> {
         report_type,
         variant_filter,
         skip_passed,
+        witness_only,
         test_timeout,
         parsed_tests_path,
         simple_progress_indicator,
@@ -119,6 +120,7 @@ async fn run() -> anyhow::Result<bool> {
         simple_progress_indicator,
         &mut persistent_test_state,
         abort_recv,
+        witness_only,
         test_timeout.map(|t| t.into()),
     ) {
         Ok(r) => r,

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -260,13 +260,10 @@ fn run_test_and_get_test_result(test: TestVariantRunInfo) -> TestStatus {
     // If a test has such issue, we "try" proving it with an altered gaslimit,
     // and will ignore it if proving the altered inputs failed so as to not
     // have false positives.
-    let mut inputs = test.gen_inputs.clone();
+    let mut inputs = test.gen_inputs;
     let is_gaslimit_changed =
-        if TryInto::<u32>::try_into(inputs.block_metadata.block_gaslimit).is_ok() {
-            false
-        } else {
-            true
-        };
+        TryInto::<u32>::try_into(inputs.block_metadata.block_gaslimit).is_err();
+
     if is_gaslimit_changed {
         inputs.block_metadata.block_gaslimit = U256::from(u32::MAX);
     }

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -271,10 +271,6 @@ fn run_test_and_get_test_result(test: TestVariantRunInfo) -> TestStatus {
         inputs.block_metadata.block_gaslimit = U256::from(u32::MAX);
     }
 
-    // The fields `block_gaslimit` and `block_gas_used` are currently supported up
-    // to 64 bits by plonky2 zkEVM for testing purposes only against the EVM test
-    // Suite. This will be reverted to have them fit in 32 bits before going into
-    // production.
     let proof_run_res = prove::<GoldilocksField, KeccakGoldilocksConfig, 2>(
         &AllStark::default(),
         &StarkConfig::standard_fast_config(),

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -276,13 +276,13 @@ fn run_test_and_get_test_result(test: TestVariantRunInfo) -> TestStatus {
         }
     };
 
-    if verify_proof(
+    let verif_output = verify_proof(
         &AllStark::default(),
         proof_run_output,
         &StarkConfig::standard_fast_config(),
-    )
-    .is_err()
-    {
+    );
+    if verif_output.is_err() {
+        warn!("Verification failed with error: {:?}", verif_output);
         return TestStatus::EvmErr("Proof verification failed.".to_string());
     }
 

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -181,18 +181,12 @@ async fn parse_test(
 
     let v_out = parsed_test.into_filtered_variants(variant_filter);
 
-    let root_test_name = get_file_stem(&path)?;
-    let t_name_f: Box<dyn Fn(usize) -> String> = match v_out.variants.len() {
-        1 if v_out.tot_variants_without_filter == 1 => Box::new(|_| root_test_name.clone()),
-        _ => Box::new(|i| format!("{}_{}", root_test_name, i)),
-    };
-
     let blacklist_ref = blacklist.as_deref();
     Ok(v_out
         .variants
         .into_iter()
         .filter_map(|info| {
-            let name = t_name_f(info.variant_idx);
+            let name = info.variant_name.clone();
             (!blacklisted(blacklist_ref, &name)).then_some(Test { name, info })
         })
         .collect())


### PR DESCRIPTION
Added a flag to only generate the witness for when we don't want to spend the time generating the proof as well.

A few notes:
- I'm not sure if there are any other checks that we should be doing on the generated witness. Right now I am assuming that it passes as long as it doesn't return an error.
- Let me know if the prog arg documentation on the new flag is a bit off.