### PR TITLE
minor: add Cancun folder

### DIFF
--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -3,4 +3,4 @@ pub(crate) const ETH_TESTS_REPO_LOCAL_PATH: &str = "eth_tests";
 pub(crate) const GENERAL_GROUP: &str = "BlockchainTests";
 pub(crate) const TEST_GROUPS: [&str; 1] = ["GeneralStateTests"];
 // The following subgroups contain subfolders unlike the other test folders.
-pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 2] = ["Shanghai", "VMTests"];
+pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 3] = ["Cancun", "Shanghai", "VMTests"];


### PR DESCRIPTION
The Cancun folder in Ethereum/tests contains some test variants for the Shanghai HF.