### PR TITLE
Distinguish passed tests

### DIFF
--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -67,7 +67,7 @@ async fn run() -> anyhow::Result<bool> {
     let passed_t_names = skip_passed.then(|| {
         Arc::new(
             persistent_test_state
-                .get_tests_that_have_passed()
+                .get_tests_that_have_passed(witness_only)
                 .map(|t| t.to_string())
                 .collect(),
         )

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -78,7 +78,7 @@ impl TestRunEntries {
         self.0.iter().filter_map(move |(name, info)| {
             info.pass_state
                 .get_passed_status(witness_only)
-                .then(|| name.as_str())
+                .then_some(name.as_str())
         })
     }
 }

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -67,9 +67,18 @@ impl TestRunEntries {
         }
     }
 
-    pub(crate) fn get_tests_that_have_passed(&self) -> impl Iterator<Item = &str> {
-        self.0.iter().filter_map(|(name, info)| {
-            matches!(info.pass_state, PassState::Passed | PassState::Ignored).then(|| name.as_str())
+    /// Filters previously passed tests if the `skip_passed` argument is used.
+    /// The filtering will always ignore tests for which proof verification was
+    /// successful, but may not skip tests for which only witness generation
+    /// was tested, if we haven't passed the `witness_only` argument.
+    pub(crate) fn get_tests_that_have_passed(
+        &self,
+        witness_only: bool,
+    ) -> impl Iterator<Item = &str> {
+        self.0.iter().filter_map(move |(name, info)| {
+            info.pass_state
+                .get_passed_status(witness_only)
+                .then(|| name.as_str())
         })
     }
 }
@@ -90,17 +99,33 @@ impl From<Vec<SerializableRunEntry>> for TestRunEntries {
 
 #[derive(Copy, Clone, Debug, Deserialize, Default, Serialize)]
 pub(crate) enum PassState {
-    Passed,
+    PassedWitness,
+    PassedProof,
     Ignored,
     Failed,
     #[default]
     NotRun,
 }
 
+impl PassState {
+    // Utility method to filter out passed tests from previous runs.
+    fn get_passed_status(&self, witness_only: bool) -> bool {
+        if witness_only {
+            matches!(
+                self,
+                Self::PassedWitness | Self::PassedProof | Self::Ignored
+            )
+        } else {
+            matches!(self, Self::PassedProof | Self::Ignored)
+        }
+    }
+}
+
 impl From<TestStatus> for PassState {
     fn from(v: TestStatus) -> Self {
         match v {
-            TestStatus::Passed => PassState::Passed,
+            TestStatus::PassedWitness => PassState::PassedWitness,
+            TestStatus::PassedProof => PassState::PassedProof,
             TestStatus::Ignored => PassState::Ignored,
             TestStatus::EvmErr(_) | TestStatus::TimedOut => PassState::Failed,
         }

--- a/evm_test_runner/src/report_generation.rs
+++ b/evm_test_runner/src/report_generation.rs
@@ -118,7 +118,12 @@ impl From<TestSubGroupRunResults> for TemplateSubGroupResultsData {
         let tests: Vec<TestRunResult> = v.test_res.into_iter().collect();
         let num_passed = tests
             .iter()
-            .filter(|t| matches!(t.status, TestStatus::Passed))
+            .filter(|t| {
+                matches!(
+                    t.status,
+                    TestStatus::PassedProof | TestStatus::PassedWitness
+                )
+            })
             .count();
 
         Self {


### PR DESCRIPTION
This makes a distinction between passed tests from a `witness-only` run vs a `proving` run, as there is currently no distinction. Now:
- calling `-w` when running with the `-p` argument will skip all previously passed tests, regardless of the type of run they went through
- calling `-p` without specifying `-w` will only discard previously passed tests with full proving enabled (and will re-run tests where only witness was generated).

I initially wanted to have something like:

```rust
pub(crate) enum PassState {
    Passed(PassedStatus),
    Ignored,
    Failed,
    #[default]
    NotRun,
}
```

but it seems serde and CSV writer don't work well with nested enums? 


closes #40 