### PR TITLE
Bump with latest plonky2 API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=47e24306b7dc224383712a6700986331615f3e2a#47e24306b7dc224383712a6700986331615f3e2a"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=71dff6e9827f501bc59416dc25ce06c4aec030ab#71dff6e9827f501bc59416dc25ce06c4aec030ab"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=47e24306b7dc224383712a6700986331615f3e2a#47e24306b7dc224383712a6700986331615f3e2a"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=71dff6e9827f501bc59416dc25ce06c4aec030ab#71dff6e9827f501bc59416dc25ce06c4aec030ab"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=47e24306b7dc224383712a6700986331615f3e2a#47e24306b7dc224383712a6700986331615f3e2a"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=71dff6e9827f501bc59416dc25ce06c4aec030ab#71dff6e9827f501bc59416dc25ce06c4aec030ab"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=47e24306b7dc224383712a6700986331615f3e2a#47e24306b7dc224383712a6700986331615f3e2a"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=71dff6e9827f501bc59416dc25ce06c4aec030ab#71dff6e9827f501bc59416dc25ce06c4aec030ab"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=47e24306b7dc224383712a6700986331615f3e2a#47e24306b7dc224383712a6700986331615f3e2a"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=71dff6e9827f501bc59416dc25ce06c4aec030ab#71dff6e9827f501bc59416dc25ce06c4aec030ab"
 
 [[package]]
 name = "portable-atomic"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "47e24306b7dc224383712a6700986331615f3e2a" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
 serde = {version = "1.0.163", features = ["derive"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -49,7 +49,7 @@ impl ParsedTestManifest {
                     signed_txn: Some(t_var.txn_bytes),
                     tries: t_var.plonky2_metadata.tries.clone(),
                     trie_roots_after,
-                    genesis_state_trie_root: t_var.plonky2_metadata.genesis_state_root,
+                    checkpoint_state_trie_root: t_var.plonky2_metadata.genesis_state_root,
                     contract_code: t_var.plonky2_metadata.contract_code.clone(),
                     block_metadata: t_var.plonky2_metadata.block_metadata.clone(),
                     txn_number_before: U256::zero(),

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "47e24306b7dc224383712a6700986331615f3e2a" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "47e24306b7dc224383712a6700986331615f3e2a" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "47e24306b7dc224383712a6700986331615f3e2a" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"


### PR DESCRIPTION
Just update the runner with latest API changes (i.e. `genesis_state_trie_root` -> `checkpoint_state_trie_root`).