### PR TITLE
Add blacklist option

### DIFF
--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -21,6 +21,12 @@ pub(crate) struct ProgArgs {
     /// The path to the parsed tests directory.
     pub(crate) parsed_tests_path: Option<PathBuf>,
 
+    /// An optional path to a blacklist file containing test variants to prevent
+    /// from running. This can be used to skip particularly heavy or badly
+    /// configured tests.
+    #[arg(short = 'b', long)]
+    pub(crate) blacklist_path: Option<PathBuf>,
+
     /// The type of report to generate.
     #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
     pub(crate) report_type: ReportType,

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -1,4 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::{BufRead, BufReader, Result as IoResult},
+    path::PathBuf,
+};
 
 use chrono::{DateTime, Utc};
 use log::info;
@@ -169,4 +174,9 @@ pub(crate) fn load_existing_pass_state_from_disk_if_exists_or_create() -> TestRu
             info!("No existing test run state found.");
             TestRunEntries::default()
         })
+}
+
+pub(crate) fn load_blacklist(blacklist_file: &PathBuf) -> IoResult<HashSet<String>> {
+    let file = File::open(blacklist_file)?;
+    Ok(BufReader::new(file).lines().flatten().collect())
 }


### PR DESCRIPTION
This PR adds a blacklist mechanism, which prevents some specified test variants from being run, similarly to how the `-p` argument ignores already passed tests.

There is now a new `--blacklist_path some_path` argument. Note that there are currently two tests that ***cannot*** be proven because of a bad starting config. I haven't included them in a default blacklist, as I think it's better to just ignore them from the parser side directly (I'll do that in a follow-up PR).

I'll also tackle the README update in one shot later, given that we should probably document all the optional commands and the independent logics of the parser / the runner (cf #49).

closes #48 