### PR TITLE
Ignore bad variant of `InitCollision`

### DIFF
--- a/eth_test_parser/src/fs_scaffolding.rs
+++ b/eth_test_parser/src/fs_scaffolding.rs
@@ -133,7 +133,6 @@ fn get_deserialized_test_body(entry: &DirEntry) -> Result<Vec<TestBody>> {
     let tests: Vec<TestBody> = test_file
         .0
         .into_values()
-        .into_iter()
         // This test has an impossible configuration, ans is hence not provable.
         .filter(|t| !t.name.contains("InitCollision_d2g0v0_Shanghai"))
         .collect();

--- a/eth_test_parser/src/fs_scaffolding.rs
+++ b/eth_test_parser/src/fs_scaffolding.rs
@@ -130,7 +130,13 @@ fn get_deserialized_test_body(entry: &DirEntry) -> Result<Vec<TestBody>> {
     let buf = BufReader::new(File::open(entry.path())?);
     let test_file: TestFile = serde_json::from_reader(buf)?;
 
-    let tests: Vec<TestBody> = test_file.0.into_values().collect();
+    let tests: Vec<TestBody> = test_file
+        .0
+        .into_values()
+        .into_iter()
+        // This test has an impossible configuration, ans is hence not provable.
+        .filter(|t| !t.name.contains("InitCollision_d2g0v0_Shanghai"))
+        .collect();
     if tests.is_empty() {
         Err(anyhow!("No valid tests found"))
     } else {


### PR DESCRIPTION
There were 2 tests for which proving was failing because of an initial impossible configuration (empty account with non-empty storage).

- `FailedCreateRevertsDeletion_d0g0v0_Shanghai` was implicitely removed when switching to parsing tests directly through the block RLP encodings as it contained some additional issues
- `InitCollision_d2g0v0_Shanghai` remained to be removed

Given that there is only 1 such badly formed test that is passing the RLP decoding sanity checks, I just hardcoded the variant name when filtering, similarly to how `ValueOverflow` is filtered directly a few lines above.