### PR TITLE
Update deps with new monorepo

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-06-27
+          toolchain: nightly
           override: true
 
       - name: rust-cache
@@ -55,7 +55,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-06-27
+          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "const-random",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -143,7 +144,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -235,9 +236,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -300,7 +301,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -320,10 +321,10 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "eth_trie_utils",
  "ethereum-types",
+ "evm_arithmetization",
  "flexi_logger",
- "plonky2_evm",
+ "mpt_trie",
  "serde",
 ]
 
@@ -342,23 +343,21 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
 dependencies = [
  "const-random-macro",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom",
  "once_cell",
- "proc-macro-hack",
  "tiny-keccak",
 ]
 
@@ -546,7 +545,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -557,7 +556,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -584,14 +583,14 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -636,14 +635,14 @@ dependencies = [
  "bytes",
  "clap",
  "common",
- "eth_trie_utils",
  "ethereum-types",
+ "evm_arithmetization",
  "flexi_logger",
  "futures",
  "hex",
  "keccak-hash 0.10.0",
  "log",
- "plonky2_evm",
+ "mpt_trie",
  "rlp",
  "rlp-derive",
  "serde",
@@ -651,25 +650,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
-]
-
-[[package]]
-name = "eth_trie_utils"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonZero/eth_trie_utils.git?rev=7fc3c3f54b3cec9c6fc5ffc5230910bd1cb77f76#7fc3c3f54b3cec9c6fc5ffc5230910bd1cb77f76"
-dependencies = [
- "bytes",
- "enum-as-inner",
- "ethereum-types",
- "hex",
- "keccak-hash 0.10.0",
- "log",
- "num-traits",
- "parking_lot",
- "rlp",
- "serde",
- "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -700,6 +680,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm_arithmetization"
+version = "0.1.0"
+source = "git+https://github.com/0xPolygonZero/zk_evm.git?rev=62b6f5a8fd11cfc74d32f8d598d395a46f148502#62b6f5a8fd11cfc74d32f8d598d395a46f148502"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "env_logger",
+ "ethereum-types",
+ "hashbrown 0.14.0",
+ "hex-literal",
+ "itertools",
+ "jemallocator",
+ "keccak-hash 0.10.0",
+ "log",
+ "mpt_trie",
+ "num",
+ "num-bigint",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "plonky2",
+ "plonky2_maybe_rayon",
+ "plonky2_util",
+ "rand",
+ "rand_chacha",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_json",
+ "starky",
+ "static_assertions",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "evm_test_runner"
 version = "0.1.0"
 dependencies = [
@@ -712,6 +727,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "ethereum-types",
+ "evm_arithmetization",
  "flexi_logger",
  "futures",
  "humantime",
@@ -719,7 +735,6 @@ dependencies = [
  "keccak-hash 0.10.0",
  "log",
  "plonky2",
- "plonky2_evm",
  "serde",
  "serde_cbor",
  "similar",
@@ -835,7 +850,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1192,12 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -1267,6 +1279,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpt_trie"
+version = "0.1.0"
+source = "git+https://github.com/0xPolygonZero/zk_evm.git?rev=62b6f5a8fd11cfc74d32f8d598d395a46f148502#62b6f5a8fd11cfc74d32f8d598d395a46f148502"
+dependencies = [
+ "bytes",
+ "enum-as-inner",
+ "ethereum-types",
+ "hex",
+ "keccak-hash 0.10.0",
+ "log",
+ "num",
+ "num-traits",
+ "parking_lot",
+ "rlp",
+ "serde",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1403,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -1498,7 +1530,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1527,7 +1559,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=ca2e56e23bd91859f387ae00c8647ca735efeb0f#ca2e56e23bd91859f387ae00c8647ca735efeb0f"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=710225c9e0ac5822b2965ce74951cf000bbb8a2c#710225c9e0ac5822b2965ce74951cf000bbb8a2c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1546,46 +1578,13 @@ dependencies = [
  "serde_json",
  "static_assertions",
  "unroll",
-]
-
-[[package]]
-name = "plonky2_evm"
-version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=ca2e56e23bd91859f387ae00c8647ca735efeb0f#ca2e56e23bd91859f387ae00c8647ca735efeb0f"
-dependencies = [
- "anyhow",
- "bytes",
- "env_logger",
- "eth_trie_utils",
- "ethereum-types",
- "hashbrown 0.14.0",
- "hex-literal",
- "itertools",
- "jemallocator",
- "keccak-hash 0.10.0",
- "log",
- "num",
- "num-bigint",
- "once_cell",
- "pest",
- "pest_derive",
- "plonky2",
- "plonky2_maybe_rayon",
- "plonky2_util",
- "rand",
- "rand_chacha",
- "rlp",
- "rlp-derive",
- "serde",
- "serde_json",
- "static_assertions",
- "tiny-keccak",
+ "web-time",
 ]
 
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=ca2e56e23bd91859f387ae00c8647ca735efeb0f#ca2e56e23bd91859f387ae00c8647ca735efeb0f"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=710225c9e0ac5822b2965ce74951cf000bbb8a2c#710225c9e0ac5822b2965ce74951cf000bbb8a2c"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1600,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=ca2e56e23bd91859f387ae00c8647ca735efeb0f#ca2e56e23bd91859f387ae00c8647ca735efeb0f"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=710225c9e0ac5822b2965ce74951cf000bbb8a2c#710225c9e0ac5822b2965ce74951cf000bbb8a2c"
 dependencies = [
  "rayon",
 ]
@@ -1608,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=ca2e56e23bd91859f387ae00c8647ca735efeb0f#ca2e56e23bd91859f387ae00c8647ca735efeb0f"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=710225c9e0ac5822b2965ce74951cf000bbb8a2c#710225c9e0ac5822b2965ce74951cf000bbb8a2c"
 
 [[package]]
 name = "portable-atomic"
@@ -1665,25 +1664,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1833,9 +1826,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -1852,13 +1845,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1897,7 +1890,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1973,6 +1966,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "starky"
+version = "0.1.2"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=710225c9e0ac5822b2965ce74951cf000bbb8a2c#710225c9e0ac5822b2965ce74951cf000bbb8a2c"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "hashbrown 0.14.0",
+ "itertools",
+ "log",
+ "num-bigint",
+ "plonky2",
+ "plonky2_maybe_rayon",
+ "plonky2_util",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2037,22 +2046,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2129,7 +2138,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2260,7 +2269,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
  "wasm-bindgen-shared",
 ]
 
@@ -2282,7 +2291,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.49",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2292,6 +2301,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "web-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2481,4 +2500,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ categories = ["cryptography"]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 clap = {version = "4.2.7", features = ["derive"] }
 ethereum-types = "0.14.1"
-eth_trie_utils = { git = "https://github.com/0xPolygonZero/eth_trie_utils.git", rev = "7fc3c3f54b3cec9c6fc5ffc5230910bd1cb77f76" }
+mpt_trie = { git = "https://github.com/0xPolygonZero/zk_evm.git", rev = "62b6f5a8fd11cfc74d32f8d598d395a46f148502" }
 flexi_logger = { version = "0.25.4", features = ["async"] }
 futures = "0.3.28"
 keccak-hash = "0.10.0"
 log = "0.4.17"
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "ca2e56e23bd91859f387ae00c8647ca735efeb0f" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "ca2e56e23bd91859f387ae00c8647ca735efeb0f" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+evm_arithmetization = { git = "https://github.com/0xPolygonZero/zk_evm.git", rev = "62b6f5a8fd11cfc74d32f8d598d395a46f148502" }
 serde = "1.0.163"
 serde_cbor = "0.11.2"
 tokio = { version = "1.28.1" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 ethereum-types = { workspace = true }
-eth_trie_utils = { workspace = true }
+mpt_trie = { workspace = true }
 flexi_logger = { workspace = true }
-plonky2_evm = { workspace = true }
+evm_arithmetization = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -6,8 +6,8 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use ethereum_types::{Address, H256, U256};
-use plonky2_evm::proof::{BlockHashes, TrieRoots};
-use plonky2_evm::{
+use evm_arithmetization::proof::{BlockHashes, TrieRoots};
+use evm_arithmetization::{
     generation::{GenerationInputs, TrieInputs},
     proof::BlockMetadata,
 };

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 common = { path = "../common" }
-eth_trie_utils = { workspace = true }
-plonky2_evm = { workspace = true }
+mpt_trie = { workspace = true }
+evm_arithmetization = { workspace = true }
 
 anyhow = { workspace = true }
 bytes = "1.4.0"

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -3,11 +3,11 @@ use std::{collections::HashMap, marker::PhantomData};
 use anyhow::Result;
 use bytes::Bytes;
 use ethereum_types::{Address, H160, H256, U256};
-use hex::FromHex;
-use plonky2_evm::generation::mpt::transaction_testing::{
+use evm_arithmetization::generation::mpt::transaction_testing::{
     AccessListItemRlp, AccessListTransactionRlp, AddressOption, FeeMarketTransactionRlp,
     LegacyTransactionRlp,
 };
+use hex::FromHex;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::RlpDecodable;
 use serde::de::MapAccess;

--- a/eth_test_parser/src/fs_scaffolding.rs
+++ b/eth_test_parser/src/fs_scaffolding.rs
@@ -130,12 +130,7 @@ fn get_deserialized_test_body(entry: &DirEntry) -> Result<Vec<TestBody>> {
     let buf = BufReader::new(File::open(entry.path())?);
     let test_file: TestFile = serde_json::from_reader(buf)?;
 
-    let tests: Vec<TestBody> = test_file
-        .0
-        .into_values()
-        // This test has an impossible configuration, ans is hence not provable.
-        .filter(|t| !t.name.contains("InitCollision_d2g0v0_Shanghai"))
-        .collect();
+    let tests: Vec<TestBody> = test_file.0.into_values().collect();
     if tests.is_empty() {
         Err(anyhow!("No valid tests found"))
     } else {

--- a/eth_test_parser/src/trie_builder.rs
+++ b/eth_test_parser/src/trie_builder.rs
@@ -3,7 +3,7 @@
 //!
 //! In other words
 //! ```ignore
-//! crate::deserialize::TestBody -> plonky2_evm::generation::GenerationInputs
+//! crate::deserialize::TestBody -> evm_arithmetization::generation::GenerationInputs
 //! ```
 use std::collections::HashMap;
 
@@ -12,13 +12,13 @@ use common::{
     config::ETHEREUM_CHAIN_ID,
     types::{ExpectedFinalRoots, Plonky2ParsedTest, TestMetadata},
 };
-use eth_trie_utils::{
+use ethereum_types::{H256, U256};
+use evm_arithmetization::{generation::TrieInputs, proof::BlockMetadata};
+use keccak_hash::keccak;
+use mpt_trie::{
     nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, PartialTrie},
 };
-use ethereum_types::{H256, U256};
-use keccak_hash::keccak;
-use plonky2_evm::{generation::TrieInputs, proof::BlockMetadata};
 use rlp::Encodable;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 common = { path = "../common" }
 plonky2 = { workspace = true }
-plonky2_evm = { workspace = true }
+evm_arithmetization = { workspace = true }
 
 anyhow = { workspace = true }
 askama = "0.12.0"

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -178,5 +178,5 @@ pub(crate) fn load_existing_pass_state_from_disk_if_exists_or_create() -> TestRu
 
 pub(crate) fn load_blacklist(blacklist_file: &PathBuf) -> IoResult<HashSet<String>> {
     let file = File::open(blacklist_file)?;
-    Ok(BufReader::new(file).lines().flatten().collect())
+    Ok(BufReader::new(file).lines().map_while(Result::ok).collect())
 }

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -8,16 +8,15 @@ use std::{
 
 use common::types::TestVariantRunInfo;
 use ethereum_types::U256;
+use evm_arithmetization::{
+    generation::generate_traces, prover::prove, verifier::verify_proof, AllStark, StarkConfig,
+};
 use futures::executor::block_on;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::warn;
 use plonky2::{
     field::goldilocks_field::GoldilocksField, plonk::config::KeccakGoldilocksConfig,
     util::timing::TimingTree,
-};
-use plonky2_evm::{
-    all_stark::AllStark, config::StarkConfig, generation::generate_traces, prover::prove,
-    verifier::verify_proof,
 };
 use tokio::{select, time::timeout};
 


### PR DESCRIPTION
Now refers to 0xPolygonZero/zk_evm with updated dependencies names.

Also removes filtering to ignore a badly configured test, as it has been removed upstream, see https://github.com/ethereum/tests/pull/1335.