### PR TITLE
Use faster witness-only testing method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "evm_arithmetization"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d80801ec98b39dde6182d34f76f11abe050302f36d8847bfcd4456ecd990c9b"
+checksum = "ef2af65f5b147f04c94df5df5e21ff9d1632fd357511e183d5e04de059d6fa93"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "mpt_trie"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc408af26fe8f58787fb1be1a3bbfdd041bc36a15d4075fdadde07028469381"
+checksum = "bbf6d77f630021e46e127abfa047aebfba78bf207ed3dfd1c4f9e2370f9b60cd"
 dependencies = [
  "bytes",
  "enum-as-inner",
@@ -1972,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "starky"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edb3b04ef3bb95f31805b9c88a9de39767089adadc1966ddc3c43348a11464a"
+checksum = "24e0a1eec739c7a67cb1c6f916c0b7bf2d281cf2edb35d3db5caa6989090133e"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,18 @@ categories = ["cryptography"]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 clap = {version = "4.2.7", features = ["derive"] }
 ethereum-types = "0.14.1"
-mpt_trie = "0.1.0"
 flexi_logger = { version = "0.25.4", features = ["async"] }
 futures = "0.3.28"
 keccak-hash = "0.10.0"
 log = "0.4.17"
-plonky2 = "0.2.0"
-evm_arithmetization = "0.1.0"
 serde = "1.0.163"
 serde_cbor = "0.11.2"
 tokio = { version = "1.28.1" }
+
+# zk-evm dependencies
+plonky2 = "0.2.0"
+mpt_trie = "0.1.1"
+evm_arithmetization = "0.1.1"
 
 [profile.release]
 opt-level = 3

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -9,7 +9,9 @@ use std::{
 use common::types::TestVariantRunInfo;
 use ethereum_types::U256;
 use evm_arithmetization::{
-    generation::generate_traces, prover::prove, verifier::verify_proof, AllStark, StarkConfig,
+    prover::{prove, testing::simulate_execution},
+    verifier::verify_proof,
+    AllStark, StarkConfig,
 };
 use futures::executor::block_on;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -260,12 +262,7 @@ fn run_test_and_get_test_result(test: TestVariantRunInfo, witness_only: bool) ->
 
     match witness_only {
         true => {
-            let res = generate_traces::<GoldilocksField, 2>(
-                &AllStark::default(),
-                test.gen_inputs,
-                &StarkConfig::standard_fast_config(),
-                &mut TimingTree::default(),
-            );
+            let res = simulate_execution::<GoldilocksField>(test.gen_inputs);
 
             if let Err(evm_err) = res {
                 return handle_evm_err(evm_err, false, "witness generation");

--- a/evm_test_runner/src/report_generation.rs
+++ b/evm_test_runner/src/report_generation.rs
@@ -153,7 +153,7 @@ impl PassedInfo {
     }
 }
 
-///
+/// Print the test report to the terminal.
 pub(crate) fn output_test_report_for_terminal(
     res: &[TestGroupRunResults],
     test_filter_str: Option<String>,


### PR DESCRIPTION
Bump `evm_arithmetization` to `v0.1.1` and leverage faster method for testing in `witness-only` mode.