### PR TITLE
Fix Shanghai tests parsing

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,4 +1,7 @@
 pub const GENERATION_INPUTS_DEFAULT_OUTPUT_DIR: &str = "generation_inputs";
+/// The source directory to look for tests to parse.
+/// We use the `BlockchainTests` subdirectory of the `Cancun` folder
+/// as it contains all hardfork variants up to this one.
 pub const MAIN_TEST_DIR: &str = "Cancun/BlockchainTests";
 pub const MATIC_CHAIN_ID: u64 = 137;
 pub const ETHEREUM_CHAIN_ID: u64 = 1;

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,4 +1,4 @@
 pub const GENERATION_INPUTS_DEFAULT_OUTPUT_DIR: &str = "generation_inputs";
-pub const MAIN_TEST_DIR: &str = "BlockchainTests";
+pub const MAIN_TEST_DIR: &str = "Cancun/BlockchainTests";
 pub const MATIC_CHAIN_ID: u64 = 137;
 pub const ETHEREUM_CHAIN_ID: u64 = 1;

--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -1,7 +1,7 @@
 use common::config::MAIN_TEST_DIR;
 
 // The PR <https://github.com/ethereum/tests/pull/1380> moved all test versions prior Cancun HF
-// to the `LegacyTests` folder instead.
+// to the `LegacyTests` folder.
 pub(crate) const ETH_TESTS_REPO_URL: &str = "https://github.com/ethereum/legacytests.git";
 pub(crate) const ETH_TESTS_REPO_LOCAL_PATH: &str = "eth_tests";
 pub(crate) const GENERAL_GROUP: &str = MAIN_TEST_DIR;

--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -8,3 +8,27 @@ pub(crate) const GENERAL_GROUP: &str = MAIN_TEST_DIR;
 pub(crate) const TEST_GROUPS: [&str; 1] = ["GeneralStateTests"];
 // The following subgroups contain subfolders unlike the other test folders.
 pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 2] = ["Shanghai", "VMTests"];
+
+/// These test variants are used for stress testing. As such, they have
+/// unrealistic scenarios that go beyond the provable bounds of the zkEVM.
+/// Witness generation for these variants is still possible, but takes too
+/// much time to be useful and usable in testing occuring regularly.
+pub(crate) const UNPROVABLE_VARIANTS: [&str; 17] = [
+    "CALLBlake2f_d9g0v0_Shanghai",
+    "CALLCODEBlake2f_d9g0v0_Shanghai",
+    "Call50000_d0g1v0_Shanghai",
+    "Callcode50000_d0g1v0_Shanghai",
+    "static_Call50000_d1g0v0_Shanghai",
+    "static_Call50000_ecrec_d0g0v0_Shanghai",
+    "static_Call50000_ecrec_d1g0v0_Shanghai",
+    "static_Call50000_identity2_d0g0v0_Shanghai",
+    "static_Call50000_identity2_d1g0v0_Shanghai",
+    "static_Call50000_identity_d0g0v0_Shanghai",
+    "static_Call50000_identity_d1g0v0_Shanghai",
+    "static_Call50000_rip160_d0g0v0_Shanghai",
+    "static_Call50000_sha256_d0g0v0_Shanghai",
+    "static_Call50000_sha256_d1g0v0_Shanghai",
+    "static_Return50000_2_d0g0v0_Shanghai",
+    "Return50000_d0g1v0_Shanghai",
+    "Return50000_2_d0g1v0_Shanghai",
+];

--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -1,6 +1,10 @@
-pub(crate) const ETH_TESTS_REPO_URL: &str = "https://github.com/ethereum/tests.git";
+use common::config::MAIN_TEST_DIR;
+
+// The PR <https://github.com/ethereum/tests/pull/1380> moved all test versions prior Cancun HF
+// to the `LegacyTests` folder instead.
+pub(crate) const ETH_TESTS_REPO_URL: &str = "https://github.com/ethereum/legacytests.git";
 pub(crate) const ETH_TESTS_REPO_LOCAL_PATH: &str = "eth_tests";
-pub(crate) const GENERAL_GROUP: &str = "BlockchainTests";
+pub(crate) const GENERAL_GROUP: &str = MAIN_TEST_DIR;
 pub(crate) const TEST_GROUPS: [&str; 1] = ["GeneralStateTests"];
 // The following subgroups contain subfolders unlike the other test folders.
-pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 3] = ["Cancun", "Shanghai", "VMTests"];
+pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 2] = ["Shanghai", "VMTests"];

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -16,6 +16,8 @@ use serde::{
 };
 use serde_with::serde_as;
 
+use crate::config::UNPROVABLE_VARIANTS;
+
 #[derive(Deserialize, Debug, Clone)]
 // "self" just points to this module.
 pub(crate) struct ByteString(#[serde(with = "self")] pub(crate) Vec<u8>);
@@ -339,7 +341,9 @@ impl<'de> Deserialize<'de> for TestFile {
                 // While we are parsing many values, we only care about the ones containing
                 // `Shanghai` in their key name.
                 while let Some((key, value)) = access.next_entry::<String, ValueJson>()? {
-                    if key.contains("Shanghai") {
+                    if key.contains("Shanghai")
+                        && !UNPROVABLE_VARIANTS.iter().any(|v| key.contains(v))
+                    {
                         if value.blocks[0].transaction_sequence.is_none() {
                             let test_body = TestBody::from_parsed_json(&value, key.clone());
 


### PR DESCRIPTION
Since https://github.com/ethereum/tests/pull/1380, all tests prior to Cancun have been migrated to the `LegacyTests` repo, which makes the current parser unable to process tests for `Shanghai`.