### PR TITLE
Filter unprovable killer txn tests

### DIFF
--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -8,3 +8,27 @@ pub(crate) const GENERAL_GROUP: &str = MAIN_TEST_DIR;
 pub(crate) const TEST_GROUPS: [&str; 1] = ["GeneralStateTests"];
 // The following subgroups contain subfolders unlike the other test folders.
 pub(crate) const SPECIAL_TEST_SUBGROUPS: [&str; 2] = ["Shanghai", "VMTests"];
+
+/// These test variants are used for stress testing. As such, they have
+/// unrealistic scenarios that go beyond the provable bounds of the zkEVM.
+/// Witness generation for these variants is still possible, but takes too
+/// much time to be useful and usable in testing occuring regularly.
+pub(crate) const UNPROVABLE_VARIANTS: [&str; 17] = [
+    "CALLBlake2f_d9g0v0_Shanghai",
+    "CALLCODEBlake2f_d9g0v0_Shanghai",
+    "Call50000_d0g1v0_Shanghai",
+    "Callcode50000_d0g1v0_Shanghai",
+    "static_Call50000_d1g0v0_Shanghai",
+    "static_Call50000_ecrec_d0g0v0_Shanghai",
+    "static_Call50000_ecrec_d1g0v0_Shanghai",
+    "static_Call50000_identity2_d0g0v0_Shanghai",
+    "static_Call50000_identity2_d1g0v0_Shanghai",
+    "static_Call50000_identity_d0g0v0_Shanghai",
+    "static_Call50000_identity_d1g0v0_Shanghai",
+    "static_Call50000_rip160_d0g0v0_Shanghai",
+    "static_Call50000_sha256_d0g0v0_Shanghai",
+    "static_Call50000_sha256_d1g0v0_Shanghai",
+    "static_Return50000_2_d0g0v0_Shanghai",
+    "Return50000_d0g1v0_Shanghai",
+    "Return50000_2_d0g1v0_Shanghai",
+];

--- a/eth_test_parser/src/deserialize.rs
+++ b/eth_test_parser/src/deserialize.rs
@@ -16,6 +16,8 @@ use serde::{
 };
 use serde_with::serde_as;
 
+use crate::config::UNPROVABLE_VARIANTS;
+
 #[derive(Deserialize, Debug, Clone)]
 // "self" just points to this module.
 pub(crate) struct ByteString(#[serde(with = "self")] pub(crate) Vec<u8>);
@@ -339,7 +341,9 @@ impl<'de> Deserialize<'de> for TestFile {
                 // While we are parsing many values, we only care about the ones containing
                 // `Shanghai` in their key name.
                 while let Some((key, value)) = access.next_entry::<String, ValueJson>()? {
-                    if key.contains("Shanghai") {
+                    if key.contains("Shanghai")
+                        && !UNPROVABLE_VARIANTS.iter().any(|v| key.contains(v))
+                    {
                         if value.blocks[0].transaction_sequence.is_none() {
                             let test_body = TestBody::from_parsed_json(&value, key.clone());
 


### PR DESCRIPTION
Some tests used for stress testing incur too much overhead on the zkEVM to be actually provable (i.e. they go over Goldilocks' prime subgroup size of 2^32 elements). As such, they _cannot_ be proven with the current system we use. While continuations would solve this, proving 50Billion CPU cycles would just be too much anyway.

We can still generate their witnesses, in `-w` mode, but each take few hundred GBs, and require several hours of execution. These tests on their own don't bring much, so they can be safely removed. Smaller variants are still included when parsing and processing the tests.